### PR TITLE
Migration to JFrog Artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,11 +111,11 @@
     <distributionManagement>
         <repository>
             <id>private-repository</id>
-            <url>https://api.bintray.com/maven/hazelcast/release/betleopard/;publish=1</url>
+            <url>https://hazelcast.jfrog.io/artifactory/release</url>
         </repository>
         <snapshotRepository>
             <id>private-repository</id>
-            <url>https://api.bintray.com/maven/hazelcast/snapshot/betleopard/;publish=1</url>
+            <url>https://hazelcast.jfrog.io/artifactory/snapshot</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
We are switching the underlying hosted Maven repository due to EOL of the current solution (JFrog Bintray). This change is needed in order to make releases working again.